### PR TITLE
feat: create baseline Wallonia model

### DIFF
--- a/config/config.walloon.yaml
+++ b/config/config.walloon.yaml
@@ -1,0 +1,1103 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#top-level-configuration
+version: v2025.07.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: '%(levelname)s:%(name)s:%(message)s'
+
+remote:
+  ssh: ""
+  path: ""
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
+run:
+  prefix: ""
+  name: "walloon-model"
+  scenarios:
+    enable: false
+    file: config/scenarios.yaml
+  disable_progressbar: false
+  shared_resources:
+    policy: false
+    exclude: []
+  shared_cutouts: true
+  use_shadow_directory: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#foresight
+foresight: myopic
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#scenario
+# Wildcard docs in https://pypsa-eur.readthedocs.io/en/latest/wildcards.html
+scenario:
+  clusters:
+  - adm
+  opts:
+  - ''
+  sector_opts:
+  - ''
+  planning_horizons:
+  - 2025
+  - 2030
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
+# Walloon model: Belgium and electrical neighbors
+countries:
+- BE
+- FR
+- GB
+- NL
+- DE
+- LU
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#snapshots
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: 'left'
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
+enable:
+  retrieve: auto
+  retrieve_databundle: true
+  retrieve_cost_data: true
+  build_cutout: false
+  retrieve_cutout: true
+  drop_leap_day: true
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#co2-budget
+co2_budget:
+  2020: 0.720 # average emissions of 2019 to 2021 relative to 1990, CO2 excl LULUCF, EEA data, European Environment Agency. (2023a). Annual European Union greenhouse gas inventory 1990–2021 and inventory report 2023 - CRF Table. https://unfccc.int/documents/627830
+  2025: 0.648 # With additional measures (WAM) projection, CO2 excl LULUCF, European Environment Agency. (2023e). Member States’ greenhouse gas (GHG) emission projections 2023. https://www.eea.europa.eu/en/datahub/datahubitem-view/4b8d94a4-aed7-4e67-a54c-0623a50f48e8
+  2030: 0.450 # 55% reduction by 2030 (Ff55)
+  2035: 0.250
+  2040: 0.100 # 90% by 2040
+  2045: 0.050
+  2050: 0.000 # climate-neutral by 2050
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
+electricity:
+  voltages: [220., 300., 330., 380., 400., 500., 750.]
+  base_network: osm-prebuilt
+  osm-prebuilt-version: 0.6
+  gaslimit_enable: false
+  gaslimit: false
+  co2limit_enable: false
+  co2limit: 7.75e+7
+  co2base: 1.487e+9
+
+  operational_reserve:
+    activate: false
+    epsilon_load: 0.02
+    epsilon_vres: 0.02
+    contingency: 4000
+
+  max_hours:
+    battery: 6
+    H2: 168
+
+  extendable_carriers:
+    Generator: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, offwind-float, OCGT, CCGT]
+    StorageUnit: [] # battery, H2
+    Store: [battery, H2]
+    Link: [] # H2 pipeline
+
+  powerplants_filter: (DateOut >= 2024 or DateOut != DateOut) and not (Country == 'Germany' and Fueltype == 'Nuclear')
+  custom_powerplants: false
+  everywhere_powerplants: []
+
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass]
+  renewable_carriers: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, offwind-float, hydro]
+
+  estimate_renewable_capacities:
+    enable: true
+    from_gem: true
+    year: 2020
+    expansion_limit: false
+    technology_mapping:
+      Offshore: offwind-ac
+      Onshore: onwind
+      PV: solar
+
+  autarky:
+    enable: false
+    by_country: false
+
+  transmission_limit: vopt
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#atlite
+atlite:
+  cutout_directory: cutouts
+  default_cutout: europe-2013-sarah3-era5
+  nprocesses: 4
+  show_progress: false
+  cutouts:
+    # use 'base' to determine geographical bounds and time span from config
+    # base:
+      # module: era5
+    walloon-region-2013-era5:
+      module: [sarah, era5] # in priority order
+      x: [-5., 8.]    # Focused on Western Europe (BE and neighbors)
+      y: [49., 55.]   # Focused on Belgium and immediate neighbors
+      dx: 0.3
+      dy: 0.3
+      time: ['2013', '2013']
+      # features: [] 
+      # sarah_dir: ""
+    europe-2013-sarah3-era5:
+      module: [sarah, era5] # in priority order
+      x: [-12., 42.]
+      y: [33., 72.]
+      dx: 0.3
+      dy: 0.3
+      time: ['2013', '2013']
+      # features: [] 
+      # sarah_dir: ""
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#renewable
+renewable:
+  onwind:
+    cutout: default
+    resource:
+      method: wind
+      turbine: Vestas_V112_3MW
+      smooth: false
+      add_cutout_windspeed: true
+    resource_classes: 1
+    capacity_per_sqkm: 3
+    # correction_factor: 0.93
+    corine:
+      grid_codes: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32]
+      distance: 1000
+      distance_grid_codes: [1, 2, 3, 4, 5, 6]
+    luisa: false
+      # grid_codes: [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242]
+      # distance: 1000
+      # distance_grid_codes: [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242]
+    natura: true
+    excluder_resolution: 100
+    clip_p_max_pu: 1.e-2
+  offwind-ac:
+    cutout: default
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_2020ATB_5.5MW
+      smooth: false
+      add_cutout_windspeed: true
+    resource_classes: 1
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    corine: [44, 255]
+    luisa: false # [0, 5230]
+    natura: true
+    ship_threshold: 400
+    max_depth: 60
+    max_shore_distance: 30000
+    excluder_resolution: 200
+    clip_p_max_pu: 1.e-2
+    landfall_length: 20
+  offwind-dc:
+    cutout: default
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_2020ATB_5.5MW
+      smooth: false
+      add_cutout_windspeed: true
+    resource_classes: 1
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    corine: [44, 255]
+    luisa: false # [0, 5230]
+    natura: true
+    ship_threshold: 400
+    max_depth: 60
+    min_shore_distance: 30000
+    excluder_resolution: 200
+    clip_p_max_pu: 1.e-2
+    landfall_length: 30
+  offwind-float:
+    cutout: default
+    resource:
+      method: wind
+      turbine: NREL_ReferenceTurbine_5MW_offshore
+      smooth: false
+      add_cutout_windspeed: true
+    resource_classes: 1
+    # ScholzPhd Tab 4.3.1: 10MW/km^2
+    capacity_per_sqkm: 2
+    correction_factor: 0.8855
+    # proxy for wake losses
+    # from 10.1016/j.energy.2018.08.153
+    # until done more rigorously in #153
+    corine: [44, 255]
+    natura: true
+    ship_threshold: 400
+    excluder_resolution: 200
+    min_depth: 60
+    max_depth: 1000
+    clip_p_max_pu: 1.e-2
+    landfall_length: 40
+  solar:
+    cutout: default
+    resource:
+      method: pv
+      panel: CSi
+      orientation:
+        slope: 35.
+        azimuth: 180.
+    resource_classes: 1
+    capacity_per_sqkm: 5.1
+    # correction_factor: 0.854337
+    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: false # [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242, 1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 3210, 3320, 3330]
+    natura: true
+    excluder_resolution: 100
+    clip_p_max_pu: 1.e-2
+  solar-hsat:
+    cutout: default
+    resource:
+      method: pv
+      panel: CSi
+      orientation:
+        slope: 35.
+        azimuth: 180.
+      tracking: horizontal
+    resource_classes: 1
+    capacity_per_sqkm: 4.43 # 15% higher land usage acc. to NREL
+    corine: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 26, 31, 32]
+    luisa: false # [1111, 1121, 1122, 1123, 1130, 1210, 1221, 1222, 1230, 1241, 1242, 1310, 1320, 1330, 1410, 1421, 1422, 2110, 2120, 2130, 2210, 2220, 2230, 2310, 2410, 2420, 3210, 3320, 3330]
+    natura: true
+    excluder_resolution: 100
+    clip_p_max_pu: 1.e-2
+  hydro:
+    cutout: default
+    carriers: [ror, PHS, hydro]
+    PHS_max_hours: 6
+    hydro_max_hours: energy_capacity_totals_by_country # one of energy_capacity_totals_by_country, estimate_by_large_installations or a float
+    flatten_dispatch: false
+    flatten_dispatch_buffer: 0.2
+    clip_min_inflow: 1.0
+    eia_norm_year: false
+    eia_correct_by_capacity: false
+    eia_approximate_missing: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#conventional
+conventional:
+  unit_commitment: false
+  dynamic_fuel_price: false
+  nuclear:
+    p_max_pu: data/nuclear_p_max_pu.csv # float of file name
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#lines
+lines:
+  types:
+    63.: 94-AL1/15-ST1A 20.0
+    66.: 94-AL1/15-ST1A 20.0
+    90.: 184-AL1/30-ST1A 110.0
+    110.: 184-AL1/30-ST1A 110.0
+    132.: 243-AL1/39-ST1A 110.0
+    150.: 243-AL1/39-ST1A 110.0
+    220.: Al/St 240/40 2-bundle 220.0
+    300.: Al/St 240/40 3-bundle 300.0
+    330.: Al/St 240/40 3-bundle 300.0
+    380.: Al/St 240/40 4-bundle 380.0
+    400.: Al/St 240/40 4-bundle 380.0
+    500.: Al/St 240/40 4-bundle 380.0
+    750.: Al/St 560/50 4-bundle 750.0
+  s_max_pu: 0.7
+  s_nom_max: .inf
+  max_extension: 20000 #MW
+  length_factor: 1.25
+  reconnect_crimea: true
+  under_construction: keep # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity for lines in grid extract
+  dynamic_line_rating:
+    activate: false
+    cutout: default
+    correction_factor: 0.95
+    max_voltage_difference: false
+    max_line_rating: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#links
+links:
+  p_max_pu: 1.0
+  p_min_pu: -1.0
+  p_nom_max: .inf
+  max_extension: 30000 #MW
+  length_factor: 1.25
+  under_construction: keep # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity for lines in grid extract
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#transmission_projects
+transmission_projects:
+  enable: true
+  include:
+    tyndp2020: true
+    nep: true
+    manual: true
+  skip:
+  - upgraded_lines
+  - upgraded_links
+  status:
+  - under_construction
+  - in_permitting
+  - confirmed
+    #- planned_not_yet_permitted
+    #- under_consideration
+  new_link_capacity: zero #keep or zero
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#transformers
+transformers:
+  x: 0.1
+  s_nom: 2000.
+  type: ''
+
+# docs-load in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#load
+load:
+  fill_gaps:
+    enable: true
+    interpolate_limit: 3
+    time_shift_for_large_gaps: 1w
+  manual_adjustments: true
+  scaling_factor: 1.0
+  fixed_year: false
+  supplement_synthetic: true
+  distribution_key:
+    gdp: 0.6
+    population: 0.4
+
+# docs
+# TODO: PyPSA-Eur merge issue in prepare_sector_network.py
+# regulate what components with which carriers are kept from PyPSA-Eur;
+# some technologies are removed because they are implemented differently
+# (e.g. battery or H2 storage) or have different year-dependent costs
+# in PyPSA-Eur-Sec
+pypsa_eur:
+  Bus:
+  - AC
+  Link:
+  - DC
+  Generator:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - offwind-float
+  - solar-hsat
+  - solar
+  - ror
+  - nuclear
+  StorageUnit:
+  - PHS
+  - hydro
+  Store: []
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#energy
+energy:
+  energy_totals_year: 2019
+  base_emissions_year: 1990
+  emissions: CO2
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#biomass
+biomass:
+  year: 2030
+  scenario: ENS_Med
+  classes:
+    solid biomass:
+    - Agricultural waste
+    - Fuelwood residues
+    - Secondary Forestry residues - woodchips
+    - Sawdust
+    - Residues from landscape care
+    not included:
+    - Sugar from sugar beet
+    - Rape seed
+    - "Sunflower, soya seed "
+    - Bioethanol barley, wheat, grain maize, oats, other cereals and rye
+    - Miscanthus, switchgrass, RCG
+    - Willow
+    - Poplar
+    - FuelwoodRW
+    - C&P_RW
+    biogas:
+    - Manure solid, liquid
+    - Sludge
+    municipal solid waste:
+    - Municipal waste
+  share_unsustainable_use_retained:
+    2020: 1
+    2025: 1
+    2030: 0.66
+    2035: 0.33
+    2040: 0
+    2045: 0
+    2050: 0
+  share_sustainable_potential_available:
+    2020: 0
+    2025: 0
+    2030: 0.33
+    2035: 0.66
+    2040: 1
+    2045: 1
+    2050: 1
+
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solar-thermal
+solar_thermal:
+  clearsky_model: simple  # should be "simple" or "enhanced"?
+  orientation:
+    slope: 45.
+    azimuth: 180.
+  cutout: default
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
+existing_capacities:
+  grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # heat grouping years >= baseyear will be ignored
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
+sector:
+  transport: true
+  heating: true
+  biomass: true
+  industry: true
+  shipping: true
+  aviation: true
+  agriculture: true
+  fossil_fuels: true
+  district_heating:
+    potential: 0.6
+    progress:
+      2020: 0.0
+      2025: 0.1
+      2030: 0.25
+      2035: 0.4
+      2040: 0.55
+      2045: 0.75
+      2050: 1.0
+    district_heating_loss: 0.15
+    supply_temperature_approximation:
+      max_forward_temperature_baseyear:
+        FR: 110
+        DK: 75
+        DE: 109
+        CZ: 130
+        FI: 115
+        PL: 130
+        SE: 102
+        IT: 90
+      min_forward_temperature_baseyear:
+        DE: 82
+      return_temperature_baseyear:
+        DE: 58
+      lower_threshold_ambient_temperature: 0
+      upper_threshold_ambient_temperature: 10
+      rolling_window_ambient_temperature: 72
+      relative_annual_temperature_reduction: 0.01
+    ptes:
+      dynamic_capacity: true
+      supplemental_heating:
+        enable: false
+        booster_heat_pump: false
+      max_top_temperature: 90
+      min_bottom_temperature: 35
+    ates:
+      enable: false
+      suitable_aquifer_types:
+      - Highly productive porous aquifers
+      aquifer_volumetric_heat_capacity: 2600
+      fraction_of_aquifer_area_available: 0.2
+      effective_screen_length: 20
+      dh_area_buffer: 1000
+      capex_as_fraction_of_geothermal_heat_source: 0.75
+      recovery_factor: 0.6
+      marginal_cost_charger: 0.035
+      ignore_missing_regions: false
+    heat_source_cooling: 6 #K
+    heat_pump_cop_approximation:
+      refrigerant: ammonia
+      heat_exchanger_pinch_point_temperature_difference: 5 #K
+      isentropic_compressor_efficiency: 0.8
+      heat_loss: 0.0
+      min_delta_t_lift: 10 #K
+    limited_heat_sources:
+      geothermal:
+        constant_temperature_celsius: 65
+        ignore_missing_regions: false
+    direct_utilisation_heat_sources:
+    - geothermal
+    temperature_limited_stores:
+    - ptes
+  heat_pump_sources:
+    urban central:
+    - air
+    urban decentral:
+    - air
+    rural:
+    - air
+    - ground
+  cluster_heat_buses: true
+  heat_demand_cutout: default
+  bev_dsm_restriction_value: 0.8
+  bev_dsm_restriction_time: 7
+  transport_heating_deadband_upper: 20.
+  transport_heating_deadband_lower: 15.
+  ICE_lower_degree_factor: 0.375
+  ICE_upper_degree_factor: 1.6
+  EV_lower_degree_factor: 0.98
+  EV_upper_degree_factor: 0.63
+  bev_dsm: true
+  bev_dsm_availability: 0.5
+  bev_energy: 0.05
+  bev_charge_efficiency: 0.9
+  bev_charge_rate: 0.011
+  bev_avail_max: 0.95
+  bev_avail_mean: 0.8
+  v2g: true
+  land_transport_fuel_cell_share:
+    2020: 0
+    2025: 0
+    2030: 0
+    2035: 0
+    2040: 0
+    2045: 0
+    2050: 0
+  land_transport_electric_share:
+    2020: 0
+    2025: 0.05
+    2030: 0.2
+    2035: 0.45
+    2040: 0.7
+    2045: 0.85
+    2050: 1
+  land_transport_ice_share:
+    2020: 1
+    2025: 0.95
+    2030: 0.8
+    2035: 0.55
+    2040: 0.3
+    2045: 0.15
+    2050: 0
+  transport_electric_efficiency: 53.19 # 1 MWh_el = 53.19*100 km
+  transport_fuel_cell_efficiency: 30.003 # 1 MWh_H2 = 30.003*100 km
+  transport_ice_efficiency: 16.0712 # 1 MWh_oil = 16.0712 * 100 km
+  agriculture_machinery_electric_share: 0.5
+  agriculture_machinery_oil_share: 0.5
+  agriculture_machinery_fuel_efficiency: 0.7
+  agriculture_machinery_electric_efficiency: 0.3
+  MWh_MeOH_per_MWh_H2: 0.8787
+  MWh_MeOH_per_tCO2: 4.0321
+  MWh_MeOH_per_MWh_e: 3.6907
+  shipping_hydrogen_liquefaction: false
+  shipping_hydrogen_share:
+    2020: 0
+    2025: 0
+    2030: 0
+    2035: 0
+    2040: 0
+    2045: 0
+    2050: 0
+  shipping_methanol_share:
+    2020: 0
+    2025: 0
+    2030: 0.15
+    2035: 0.35
+    2040: 0.55
+    2045: 0.8
+    2050: 1
+  shipping_oil_share:
+    2020: 1
+    2025: 1
+    2030: 0.85
+    2035: 0.65
+    2040: 0.45
+    2045: 0.2
+    2050: 0
+  shipping_methanol_efficiency: 0.46
+  shipping_oil_efficiency: 0.40
+  aviation_demand_factor: 1.
+  HVC_demand_factor: 1.
+  time_dep_hp_cop: true
+  heat_pump_sink_T_individual_heating: 55.
+  reduce_space_heat_exogenously: true
+  reduce_space_heat_exogenously_factor:
+    2020: 0.10  # this results in a space heat demand reduction of 10%
+    2025: 0.09  # first heat demand increases compared to 2020 because of larger floor area per capita
+    2030: 0.09
+    2035: 0.11
+    2040: 0.16
+    2045: 0.21
+    2050: 0.29
+  retrofitting:
+    retro_endogen: false
+    cost_factor: 1.0
+    interest_rate: 0.04
+    annualise_cost: true
+    tax_weighting: false
+    construction_index: true
+  tes: true
+  boilers: true
+  resistive_heaters: true
+  oil_boilers: false
+  biomass_boiler: true
+  overdimension_heat_generators:
+    decentral: 1.1  #to cover demand peaks bigger than data
+    central: 1.0
+  chp:
+    enable: true
+    fuel:
+    - solid biomass # For solid biomass, CHP with and without CC are added
+    - gas # For all other fuels the same techno economic data from gas CHP is taken
+    micro_chp: false # Only gas is used for micro_chp
+  solar_thermal: true
+  solar_cf_correction: 0.788457  # =  >>> 1/1.2683
+  methanation: true
+  coal_cc: false
+  dac: true
+  co2_vent: false
+  heat_vent:
+    urban central: true
+    urban decentral: true
+    rural: true
+  marginal_cost_heat_vent: 0.02
+  allam_cycle_gas: false
+  hydrogen_fuel_cell: true
+  hydrogen_turbine: true
+  SMR: true
+  SMR_cc: true
+  regional_oil_demand: true
+  regional_coal_demand: false
+  regional_co2_sequestration_potential:
+    enable: true
+    attribute:
+    - conservative estimate Mt
+    - conservative estimate GAS Mt
+    - conservative estimate OIL Mt
+    - conservative estimate aquifer Mt
+    include_onshore: false
+    min_size: 3
+    max_size: 25
+    years_of_storage: 25
+  co2_sequestration_potential:
+    2020: 0
+    2025: 0
+    2030: 40
+    2035: 100
+    2040: 180
+    2045: 250
+    2050: 250
+  co2_sequestration_cost: 30
+  co2_sequestration_lifetime: 50
+  co2_spatial: true
+  co2_network: true
+  co2_network_cost_factor: 1
+  cc_fraction: 0.9
+  hydrogen_underground_storage: true
+  hydrogen_underground_storage_locations:
+  - onshore    # more than 50 km from sea
+  - nearshore      # within 50 km of sea
+    # - offshore
+  methanol:
+    regional_methanol_demand: false
+    methanol_reforming: false
+    methanol_reforming_cc: false
+    methanol_to_kerosene: false
+    methanol_to_power:
+      ccgt: false
+      ccgt_cc: false
+      ocgt: true
+      allam: false
+    biomass_to_methanol: true
+    biomass_to_methanol_cc: false
+  ammonia: true
+  min_part_load_fischer_tropsch: 0.5
+  min_part_load_methanolisation: 0.3
+  min_part_load_methanation: 0.3
+  use_fischer_tropsch_waste_heat: 0.25
+  use_haber_bosch_waste_heat: 0.25
+  use_methanolisation_waste_heat: 0.25
+  use_methanation_waste_heat: 0.25
+  use_fuel_cell_waste_heat: 1
+  use_electrolysis_waste_heat: 0.25
+  electricity_transmission_grid: true
+  electricity_distribution_grid: true
+  electricity_grid_connection: true
+  transmission_efficiency:
+    enable:
+    - DC
+    - H2 pipeline
+    - gas pipeline
+    - electricity distribution grid
+    DC:
+      efficiency_static: 0.98
+      efficiency_per_1000km: 0.977
+    H2 pipeline:
+      efficiency_per_1000km: 1 # 0.982
+      compression_per_1000km: 0.018
+    gas pipeline:
+      efficiency_per_1000km: 1 #0.977
+      compression_per_1000km: 0.01
+    electricity distribution grid:
+      efficiency_static: 0.97
+  H2_network: true
+  gas_network: true
+  H2_retrofit: false
+  H2_retrofit_capacity_per_CH4: 0.6
+  gas_network_connectivity_upgrade: 1
+  gas_distribution_grid: true
+  gas_distribution_grid_cost_factor: 1.0
+  biomass_spatial: true
+  biomass_transport: false
+  biogas_upgrading: true
+  biogas_upgrading_cc: false
+  conventional_generation:
+    OCGT: gas
+    CCGT: gas
+  keep_existing_capacities: false
+  biomass_to_liquid: true
+  biomass_to_liquid_cc: false
+  electrobiofuels: true
+  biosng: false
+  biosng_cc: false
+  bioH2: false
+  municipal_solid_waste: false
+  limit_max_growth:
+    enable: false
+    # allowing 30% larger than max historic growth
+    factor: 1.3
+    max_growth:  # unit GW
+      onwind: 16 # onshore max grow so far 16 GW in Europe https://www.iea.org/reports/renewables-2020/wind
+      solar: 28 # solar max grow so far 28 GW in Europe https://www.iea.org/reports/renewables-2020/solar-pv
+      offwind-ac: 35 # offshore max grow so far 3.5 GW in Europe https://windeurope.org/about-wind/statistics/offshore/european-offshore-wind-industry-key-trends-statistics-2019/
+      offwind-dc: 35
+    max_relative_growth:
+      onwind: 3
+      solar: 3
+      offwind-ac: 3
+      offwind-dc: 3
+  enhanced_geothermal:
+    enable: false
+    flexible: true
+    max_hours: 240
+    max_boost: 0.25
+    var_cf: true
+    sustainability_factor: 0.0025
+  solid_biomass_import:
+    enable: false
+    price: 54 #EUR/MWh
+    max_amount: 1390 # TWh
+    upstream_emissions_factor: .1 #share of solid biomass CO2 emissions at full combustion
+  imports:
+    enable: false
+    limit: .inf
+    limit_sense: <=
+    price:
+      H2: 74
+      NH3: 97
+      methanol: 121
+      gas: 122
+      oil: 125
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#industry
+industry:
+  St_primary_fraction:
+    2020: 0.6
+    2025: 0.55
+    2030: 0.5
+    2035: 0.45
+    2040: 0.4
+    2045: 0.35
+    2050: 0.3
+  DRI_fraction:
+    2020: 0
+    2025: 0
+    2030: 0.05
+    2035: 0.2
+    2040: 0.4
+    2045: 0.7
+    2050: 1
+  H2_DRI: 1.7
+  elec_DRI: 0.322
+  Al_primary_fraction:
+    2020: 0.4
+    2025: 0.375
+    2030: 0.35
+    2035: 0.325
+    2040: 0.3
+    2045: 0.25
+    2050: 0.2
+  MWh_NH3_per_tNH3: 5.166
+  MWh_CH4_per_tNH3_SMR: 10.8
+  MWh_elec_per_tNH3_SMR: 0.7
+  MWh_H2_per_tNH3_electrolysis: 5.93
+  MWh_elec_per_tNH3_electrolysis: 0.2473
+  MWh_NH3_per_MWh_H2_cracker: 1.46 # https://github.com/euronion/trace/blob/44a5ff8401762edbef80eff9cfe5a47c8d3c8be4/data/efficiencies.csv
+  NH3_process_emissions: 24.5
+  petrochemical_process_emissions: 25.5
+  #HVC primary/recycling based on values used in Neumann et al https://doi.org/10.1016/j.joule.2023.06.016, linearly interpolated between 2020 and 2050
+  #2020 recycling rates based on Agora https://static.agora-energiewende.de/fileadmin/Projekte/2021/2021_02_EU_CEAP/A-EW_254_Mobilising-circular-economy_study_WEB.pdf
+  #fractions refer to the total primary HVC production in 2020
+  #assumes 6.7 Mtplastics produced from recycling in 2020
+  HVC_primary_fraction:
+    2020: 0.88
+    2025: 0.85
+    2030: 0.78
+    2035: 0.7
+    2040: 0.6
+    2045: 0.5
+    2050: 0.4
+  HVC_mechanical_recycling_fraction:
+    2020: 0.12
+    2025: 0.15
+    2030: 0.18
+    2035: 0.21
+    2040: 0.24
+    2045: 0.27
+    2050: 0.30
+  HVC_chemical_recycling_fraction:
+    2020: 0.0
+    2025: 0.0
+    2030: 0.04
+    2035: 0.08
+    2040: 0.12
+    2045: 0.16
+    2050: 0.20
+  HVC_environment_sequestration_fraction: 0.
+  waste_to_energy: false
+  waste_to_energy_cc: false
+  sector_ratios_fraction_future:
+    2020: 0.0
+    2025: 0.05
+    2030: 0.2
+    2035: 0.45
+    2040: 0.7
+    2045: 0.85
+    2050: 1.0
+  basic_chemicals_without_NH3_production_today: 69. #Mt/a, = 86 Mtethylene-equiv - 17 MtNH3
+  HVC_production_today: 52.
+  MWh_elec_per_tHVC_mechanical_recycling: 0.547
+  MWh_elec_per_tHVC_chemical_recycling: 6.9
+  chlorine_production_today: 9.58
+  MWh_elec_per_tCl: 3.6
+  MWh_H2_per_tCl: -0.9372
+  methanol_production_today: 1.5
+  MWh_elec_per_tMeOH: 0.167
+  MWh_CH4_per_tMeOH: 10.25
+  MWh_MeOH_per_tMeOH: 5.528
+  hotmaps_locate_missing: false
+  reference_year: 2019
+  oil_refining_emissions: 0.013
+
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#costs
+costs:
+  year: 2050
+  version: v0.13.3
+  social_discountrate: 0.02
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    "CO2 intensity": 0
+    "discount rate": 0.07
+    "standing losses": 0
+  overwrites: {}
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+    home battery storage: 0
+    water tank charger: 0.03
+    central water pit charger: 0.025
+  emission_prices:
+    enable: false
+    co2: 0.
+    co2_monthly_prices: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#clustering
+clustering:
+  mode: administrative
+  administrative:
+    level: 0  # Default: country level for all countries
+    BE: 1     # Belgium: NUTS-1 level (3 regions: Brussels, Flanders, Wallonia)
+  focus_weights: false
+  copperplate_regions: []
+  build_bidding_zones:
+    remove_islands: false
+    aggregate_to_tyndp: false
+  simplify_network:
+    to_substations: false
+    remove_stubs: true
+    remove_stubs_across_borders: false
+  cluster_network:
+    algorithm: kmeans
+    hac_features:
+    - wnd100m
+    - influx_direct
+  exclude_carriers: []
+  consider_efficiency_classes: false
+  aggregation_strategies:
+    generators:
+      committable: any
+      ramp_limit_up: max
+      ramp_limit_down: max
+  temporal:
+    resolution_elec: 3h
+    resolution_sector: 3h
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#adjustments
+adjustments:
+  electricity: false
+  sector:
+    factor:
+      Link:
+        electricity distribution grid:
+          capital_cost: 1.0
+    absolute: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving
+solving:
+  options:
+    clip_p_max_pu: 1.e-2
+    load_shedding: false
+    curtailment_mode: false
+    noisy_costs: true
+    skip_iterations: true
+    rolling_horizon: false
+    seed: 123
+    custom_extra_functionality: "../data/custom_extra_functionality.py"
+    # io_api: "direct"  # Increases performance but only supported for the highs and gurobi solvers
+    # options that go into the optimize function
+    track_iterations: false
+    min_iterations: 2
+    max_iterations: 3
+    transmission_losses: 2
+    linearized_unit_commitment: true
+    horizon: 365
+    post_discretization:
+      enable: false
+      line_unit_size: 1700
+      line_threshold: 0.3
+      link_unit_size:
+        DC: 2000
+        H2 pipeline: 1200
+        gas pipeline: 1500
+      link_threshold:
+        DC: 0.3
+        H2 pipeline: 0.3
+        gas pipeline: 0.3
+      fractional_last_unit_size: false
+    keep_files: false
+    model_kwargs:
+      solver_dir: ""
+
+  agg_p_nom_limits:
+    agg_offwind: false
+    agg_solar: false
+    include_existing: false
+    file: data/agg_p_nom_minmax.csv
+
+  constraints:
+    CCL: false
+    EQ: false
+    BAU: false
+    SAFE: false
+
+  solver:
+    name: gurobi
+    options: gurobi-default
+
+  solver_options:
+    highs-default:
+      # refer to https://ergo-code.github.io/HiGHS/dev/options/definitions/
+      threads: 1
+      solver: "ipm"
+      run_crossover: "off"
+      small_matrix_value: 1e-6
+      large_matrix_value: 1e9
+      primal_feasibility_tolerance: 1e-5
+      dual_feasibility_tolerance: 1e-5
+      ipm_optimality_tolerance: 1e-4
+      parallel: "on"
+      random_seed: 123
+    highs-simplex:
+      solver: "simplex"
+      parallel: "on"
+      primal_feasibility_tolerance: 1e-5
+      dual_feasibility_tolerance: 1e-5
+      random_seed: 123
+    gurobi-default:
+      threads: 4
+      method: 2 # barrier
+      crossover: 0
+      BarConvTol: 1.e-5
+      Seed: 123
+      AggFill: 0
+      PreDual: 0
+      GURO_PAR_BARDENSETHRESH: 200
+    gurobi-numeric-focus:
+      NumericFocus: 3       # Favour numeric stability over speed
+      method: 2             # barrier
+      crossover: 0          # do not use crossover
+      BarHomogeneous: 1     # Use homogeneous barrier if standard does not converge
+      BarConvTol: 1.e-5
+      FeasibilityTol: 1.e-4
+      OptimalityTol: 1.e-4
+      ObjScale: -0.5
+      threads: 8
+      Seed: 123
+    gurobi-fallback:        # Use gurobi defaults
+      crossover: 0
+      method: 2             # barrier
+      BarHomogeneous: 1     # Use homogeneous barrier if standard does not converge
+      BarConvTol: 1.e-5
+      FeasibilityTol: 1.e-5
+      OptimalityTol: 1.e-5
+      Seed: 123
+      threads: 8
+    cplex-default:
+      threads: 4
+      lpmethod: 4 # barrier
+      solutiontype: 2 # non basic solution, ie no crossover
+      barrier.convergetol: 1.e-5
+      feasopt.tolerance: 1.e-6
+    copt-default:
+      Threads: 8
+      LpMethod: 2
+      Crossover: 0
+      RelGap: 1.e-6
+      Dualize: 0
+    copt-gpu:
+      LpMethod: 6
+      GPUMode: 1
+      PDLPTol: 1.e-5
+      Crossover: 0
+    cbc-default: {} # Used in CI
+    glpk-default: {} # Used in CI
+
+  check_objective:
+    enable: false
+    expected_value: None
+    atol: 1_000_000
+    rtol: 0.01
+
+  mem_mb: 128000
+  memory_logging_frequency: 5 # in seconds
+  runtime: 48h #runtime in humanfriendly style https://humanfriendly.readthedocs.io/en/latest/


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR creates a baseline model for the Wallonia region (by adding a new config file called `config.walloon.yaml`). The config file is a copy of `config.default.yaml`, with the following changes made:

Spatial configuration:
- Countries modeled: Limited to Belgium and electrical neighbors: ['BE', 'FR', 'GB', 'NL', 'DE', 'LU']
- Belgium Resolution: NUTS-1 level (3 regions: Brussels, Flanders, Wallonia)
- Other Countries Resolution: Country-level (1 node each)

Temporal Configuration:
- Resolution: 3H for both electricity and sector models
- Optimization: Myopic with 5-year steps (2025, 2030 for testing purposes right now, can expand all the way to 2050)

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
