### PR TITLE
fix: update `config.walloon.yaml` to use `resolution_elec: False` to prevent negative demands

### DIFF
--- a/config/config.walloon.yaml
+++ b/config/config.walloon.yaml
@@ -41,7 +41,7 @@ electricity:
 clustering:
   mode: custom_busmap_BE
   temporal:
-    resolution_elec: 3h
+    resolution_elec: False
     resolution_sector: 3h
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds more planning horizons to `config.walloon.yaml` (so now the planning horizons are 2025, 2030, 2040, and 2050), and changes the clustering `resolution_elec: False`. The reason for the latter is if it's set to 3H, it caused us to have negative demands.

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
