### PR TITLE
Retrofit nuclear plants that are about to be decommissioned 

### DIFF
--- a/config/config.walloon.yaml
+++ b/config/config.walloon.yaml
@@ -71,7 +71,7 @@ clustering:
   mode: custom_busmap_BE
   temporal:
     resolution_elec: False
-    resolution_sector: 3h
+    resolution_sector: 3000h
   exclude_carriers:
     - nuclear
 

--- a/data/walloon/custom_costs_rc.csv
+++ b/data/walloon/custom_costs_rc.csv
@@ -8,24 +8,27 @@ planning_horizon,technology,parameter,value,unit,source,further_description
 2030,gas,fuel,32.4,EUR/MWh_th,recommended parameters for reporting GHG projections in 2025” publie par la Direction generale de l'action pour le climat departement Strategie analyse et planification (CLIMA.A),
 2040,gas,fuel,36.36,EUR/MWh_th,recommended parameters for reporting GHG projections in 2025” publie par la Direction generale de l'action pour le climat departement Strategie analyse et planification (CLIMA.A),
 2050,gas,fuel,34.56,EUR/MWh_th,recommended parameters for reporting GHG projections in 2025” publie par la Direction generale de l'action pour le climat departement Strategie analyse et planification (CLIMA.A),
-2030,biogas upgrading,investment,244.0,EUR/kW_biogas,Valbiom,
-2040,biogas upgrading,investment,244.0,EUR/kW_biogas,Valbiom,
-2050,biogas upgrading,investment,244.0,EUR/kW_biogas,Valbiom,
-2030,nuclear,investment,9500.0,EUR/kW_e,Mecatech Forum du nucleaire IEA,
-2040,nuclear,investment,9500.0,EUR/kW_e,Mecatech Forum du nucleaire IEA,
-2050,nuclear,investment,9500.0,EUR/kW_e,Mecatech Forum du nucleaire IEA,
-2030,SMR,investment,11400.0,EUR/kW_e,Mecatech,
-2040,SMR,investment,11400.0,EUR/kW_e,Mecatech,
-2050,SMR,investment,11400.0,EUR/kW_e,Mecatech,
-2030,solar-rooftop,investment,875.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
-2040,solar-rooftop,investment,875.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
-2050,solar-rooftop,investment,875.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
-2030,solar-utility,investment,500.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
-2040,solar-utility,investment,500.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
-2050,solar-utility,investment,500.0,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
-2030,onwind,investment,1450.0,EUR/kW_e,Edora,
-2040,onwind,investment,1450.0,EUR/kW_e,Edora,
-2050,onwind,investment,1450.0,EUR/kW_e,Edora,
-2030,biogas,investment,1231.0,EUR/kW_biogas,Valbiom,
-2040,biogas,investment,1231.0,EUR/kW_biogas,Valbiom,
-2050,biogas,investment,1231.0,EUR/kW_biogas,Valbiom,
+2030,biogas upgrading,investment,244,EUR/kW_biogas,Valbiom,
+2040,biogas upgrading,investment,244,EUR/kW_biogas,Valbiom,
+2050,biogas upgrading,investment,244,EUR/kW_biogas,Valbiom,
+2030,nuclear,investment,9500,EUR/kW_e,Mecatech Forum du nucleaire IEA,
+2040,nuclear,investment,9500,EUR/kW_e,Mecatech Forum du nucleaire IEA,
+2050,nuclear,investment,9500,EUR/kW_e,Mecatech Forum du nucleaire IEA,
+2030,SMR,investment,11400,EUR/kW_e,Mecatech,
+2040,SMR,investment,11400,EUR/kW_e,Mecatech,
+2050,SMR,investment,11400,EUR/kW_e,Mecatech,
+2030,solar-rooftop,investment,875,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
+2040,solar-rooftop,investment,875,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
+2050,solar-rooftop,investment,875,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 moyenne entre une installation residentielle et une installation tertiaire en toiture (avec 50% du CAPEX d'une installation residentielle 25% d'une petite installation tertiaire et 25% d'une grande installation tertiaire)
+2030,solar-utility,investment,500,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
+2040,solar-utility,investment,500,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
+2050,solar-utility,investment,500,EUR/kW_e,IEA PVPS,Etude de marche en Hollande en 2023 installation centralisee (taille entre 10 et 50 MW)
+2030,onwind,investment,1450,EUR/kW_e,Edora,
+2040,onwind,investment,1450,EUR/kW_e,Edora,
+2050,onwind,investment,1450,EUR/kW_e,Edora,
+2030,biogas,investment,1231,EUR/kW_biogas,Valbiom,
+2040,biogas,investment,1231,EUR/kW_biogas,Valbiom,
+2050,biogas,investment,1231,EUR/kW_biogas,Valbiom,
+all,nuclear retrofit,lifetime,10,years,,
+all,nuclear retrofit,investment,1800,EUR/kW_e,,
+all,nuclear retrofit,FOM,1.27,%/year,"Lazard's levelized cost of energy analysis - version 16.0 (2023): https://www.lazard.com/media/typdgxmm/lazards-lcoeplus-april-2023.pdf , pg. 49 (Levelized Cost of Energy - Key Assumptions), accessed: 2023-12-14.",

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,8 @@ Release Notes
 PyPSA-WAL Upcoming Release
 ==========================
 
+* Allow BEWAL nuclear plants that are about to be retired to be retrofitted instead 
+  (https://github.com/open-energy-transition/pypsa-wal/pull/37).
 * Update Walloon-specific potentials for biomass (including imported, transported, and local production), 
   onshore wind, and solar using custom potentials provided in ``data/walloon/custom_potentials.csv`` 
   (https://github.com/open-energy-transition/pypsa-wal/pull/29).

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -15,6 +15,7 @@ import xarray as xr
 from scripts._helpers import (
     configure_logging,
     get_snapshots,
+    load_costs,
     sanitize_custom_columns,
     set_scenario_config,
     update_config_from_wildcards,
@@ -400,6 +401,7 @@ if __name__ == "__main__":
         n,
         decomissioned_nuclear,
         int(snakemake.wildcards.planning_horizons),
+        costs = load_costs(snakemake.input.costs),
         MILP = True,
     )
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -21,7 +21,7 @@ from scripts._helpers import (
 )
 from scripts.add_electricity import flatten, sanitize_carriers
 from scripts.add_existing_baseyear import add_build_year_to_new_assets
-from scripts.walloon_scripts.nuclear_helper import add_BEWAL_nuclear
+from scripts.walloon_scripts.nuclear_helper import add_BEWAL_nuclear, retrofit_retired_nuclear
 
 logger = logging.getLogger(__name__)
 idx = pd.IndexSlice
@@ -60,6 +60,7 @@ def add_brownfield(
     dc_i = n.links[n.links.carrier == "DC"].index
     n.links.loc[dc_i, "p_nom_min"] = n_p.links.loc[dc_i, "p_nom_opt"]
 
+    decomissioned_assets = {"Link": None, "Generator": None, "Store": None}
     for c in n_p.iterate_components(["Link", "Generator", "Store"]):
         attr = "e" if c.name == "Store" else "p"
 
@@ -68,7 +69,9 @@ def add_brownfield(
         n_p.remove(c.name, c.df.index[c.df.lifetime == np.inf])
 
         # remove assets whose build_year + lifetime <= year
-        n_p.remove(c.name, c.df.index[c.df.build_year + c.df.lifetime <= year])
+        decomissioned_assets_index = c.df.index[c.df.build_year + c.df.lifetime <= year]
+        decomissioned_assets[c.name] = c.df.loc[decomissioned_assets_index]
+        n_p.remove(c.name, decomissioned_assets_index)
 
         # remove assets if their optimized nominal capacity is lower than a threshold
         # since CHP heat Link is proportional to CHP electric Link, make sure threshold is compatible
@@ -155,6 +158,8 @@ def add_brownfield(
             )
             n.links.loc[gas_pipes_i, "p_nom"] = remaining_capacity
             n.links.loc[gas_pipes_i, "p_nom_max"] = remaining_capacity
+
+    return decomissioned_assets
 
 
 def disable_grid_expansion_if_limit_hit(n):
@@ -362,7 +367,7 @@ if __name__ == "__main__":
     if snakemake.params.tes and snakemake.params.dynamic_ptes_capacity:
         update_dynamic_ptes_capacity(n, n_p, year)
 
-    add_brownfield(
+    decomissioned_assets = add_brownfield(
         n,
         n_p,
         year,
@@ -385,6 +390,17 @@ if __name__ == "__main__":
             snakemake.config["electricity"]["extendable_carriers"]
             .get("extendable_nuclear_links", {})
         ),
+    )
+
+    decomissioned_nuclear = (
+        decomissioned_assets["Link"].query("carrier == 'nuclear'")
+    )
+
+    retrofit_retired_nuclear(
+        n,
+        decomissioned_nuclear,
+        int(snakemake.wildcards.planning_horizons),
+        MILP = True,
     )
 
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -606,7 +606,7 @@ def add_carrier_buses(
         capital_cost=capital_cost,
     )
 
-    fossils = ["coal", "gas", "oil", "lignite"]
+    fossils = ["coal", "gas", "oil", "lignite", "uranium"]
     if options["fossil_fuels"] and carrier in fossils:
         suffix = ""
 

--- a/scripts/process_cost_data.py
+++ b/scripts/process_cost_data.py
@@ -143,10 +143,10 @@ def prepare_costs(
 
     # min_count=1 is important to generate NaNs which are then filled by fillna
     costs = costs.value.unstack(level=1).groupby("technology").sum(min_count=1)
-    costs = costs.fillna(config["fill_values"])
 
     # Process overwrites for various attributes
     costs = overwrite_costs(costs, custom_raw)
+    costs = costs.fillna(config["fill_values"])
     for attr in (
         "investment",
         "lifetime",

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1448,7 +1448,7 @@ if __name__ == "__main__":
 
     retrofit_n = [c for c in n.links.index if "retrofit" in c]
     if retrofit_n != []:
-        print(n.links.loc[retrofit_n[0]])
+        print(n.links.loc[retrofit_n, ["p_nom_min", "p_nom_opt"]])
 
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1446,10 +1446,6 @@ if __name__ == "__main__":
             log_fn=snakemake.log.solver,
         )
 
-    retrofit_n = [c for c in n.links.index if "retrofit" in c]
-    if retrofit_n != []:
-        print(n.links.loc[retrofit_n, ["p_nom_min", "p_nom_opt"]])
-
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1446,6 +1446,10 @@ if __name__ == "__main__":
             log_fn=snakemake.log.solver,
         )
 
+    retrofit_n = [c for c in n.links.index if "retrofit" in c]
+    if retrofit_n != []:
+        print(n.links.loc[retrofit_n[0]])
+
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))

--- a/scripts/walloon_scripts/nuclear_helper.py
+++ b/scripts/walloon_scripts/nuclear_helper.py
@@ -48,6 +48,7 @@ def retrofit_retired_nuclear(
         n,
         decomissioned_nuclear,
         planning_horizon,
+        costs,
         extendable_nuclear_nodes = ["BEWAL"],
         MILP = False):
     """
@@ -87,15 +88,15 @@ def retrofit_retired_nuclear(
 
     # insert retrofit lifetime + capital cost here (take from costs_processed.csv, ideally represented as a separate technology "nuclear retrofit"?
     # in that case, add a new input argument costs. Otherwise, hardcode below
-    lifetime_nuclear_retro = 0.5*retrofit_nuclear["lifetime"]
-    capital_cost_nuclear_retro = 0.01
+    lifetime_nuclear_retro = costs.loc["nuclear retrofit"].loc["lifetime"]
+    capital_cost_nuclear_retro = costs.loc["nuclear retrofit"].loc["capital_cost"]
     retrofit_nuclear["lifetime"] = lifetime_nuclear_retro
     retrofit_nuclear["capital_cost"] = capital_cost_nuclear_retro
 
     logger.info(
-        f"Adding the option to retrofit the following nuclear plants: {retrofit_nuclear.index} "
-        f"to increase the lifetime of {decomissioned_nuclear.index} by {lifetime_nuclear_retro} years."
-        f"assuming a cost of capital of {capital_cost_nuclear_retro}."
+        f"Adding the option to retrofit the following nuclear plants: {decomissioned_nuclear.index} "
+        f"to increase their lifetime by {lifetime_nuclear_retro} years. "
+        f"Assuming an annualized cost of capital of {capital_cost_nuclear_retro}."
     )
 
     for name, row in retrofit_nuclear.iterrows():

--- a/scripts/walloon_scripts/nuclear_helper.py
+++ b/scripts/walloon_scripts/nuclear_helper.py
@@ -70,7 +70,6 @@ def retrofit_retired_nuclear(
         True will only allow retrofitting the entire block or nothing at all
         Turning the problem essentially into a MILP.
     """
-    # filter for BEWAL
     decomissioned_nuclear = decomissioned_nuclear.query("bus1 in @extendable_nuclear_nodes")
     retrofit_nuclear = decomissioned_nuclear.copy()
     retrofit_nuclear.index = retrofit_nuclear.index.astype(str) + " retrofit"

--- a/scripts/walloon_scripts/nuclear_helper.py
+++ b/scripts/walloon_scripts/nuclear_helper.py
@@ -42,3 +42,63 @@ def add_BEWAL_nuclear(
 
         if extendable_nuclear_links != []:
             n.links.loc[extendable_nuclear_links, "p_nom_extendable"] = True
+
+
+def retrofit_retired_nuclear(
+        n,
+        decomissioned_nuclear,
+        planning_horizon,
+        extendable_nuclear_nodes = ["BEWAL"],
+        MILP = False):
+    """
+    Provide the option to a given set of nuclear links that are being decomissioned to be retrofitted
+    and remain in the system.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        The PyPSA network object where retrofit nuclear links are being added.
+    decomissioned_nuclear : pypsa.Network
+        A PyPSA network object that contains only links of generators that are
+        being decommissioned in the considered planning horizon.
+    planning_horizon : int
+        Will become the new build_year of the retrofitted plant.
+    extendable_nuclear_nodes : list
+        list ofs name of the buses where the nuclear link shall be made
+        available for retrofitting (default ``["BEWAL"]``).
+    MILP : bool
+        True will only allow retrofitting the entire block or nothing at all
+        Turning the problem essentially into a MILP.
+    """
+    # filter for BEWAL
+    decomissioned_nuclear = decomissioned_nuclear.query("bus1 in @extendable_nuclear_nodes")
+    retrofit_nuclear = decomissioned_nuclear.copy()
+    retrofit_nuclear.index = retrofit_nuclear.index.astype(str) + " retrofit"
+    retrofit_nuclear["p_nom_max"] = (
+        retrofit_nuclear[["p_nom", "p_nom_opt"]]
+        .apply(pd.to_numeric, errors="coerce")
+        .max(axis=1)
+        .fillna(0.0)
+    )
+    if MILP:
+        retrofit_nuclear["p_nom_mod"] = retrofit_nuclear["p_nom_max"]
+    retrofit_nuclear[["p_nom_opt", "p_nom", "p_nom_min"]] = 0.1
+    retrofit_nuclear["p_nom_extendable"] = True
+    retrofit_nuclear["build_year"] = planning_horizon
+
+    # insert retrofit lifetime + capital cost here (take from costs_processed.csv, ideally represented as a separate technology "nuclear retrofit"?
+    # in that case, add a new input argument costs. Otherwise, hardcode below
+    lifetime_nuclear_retro = 0.5*retrofit_nuclear["lifetime"]
+    capital_cost_nuclear_retro = 0.01
+    retrofit_nuclear["lifetime"] = lifetime_nuclear_retro
+    retrofit_nuclear["capital_cost"] = capital_cost_nuclear_retro
+
+    logger.info(
+        f"Adding the option to retrofit the following nuclear plants: {retrofit_nuclear.index} "
+        f"to increase the lifetime of {decomissioned_nuclear.index} by {lifetime_nuclear_retro} years."
+        f"assuming a cost of capital of {capital_cost_nuclear_retro}."
+    )
+
+    for name, row in retrofit_nuclear.iterrows():
+        attrs = row.dropna().to_dict()
+        n.add("Link", name=name, **attrs)


### PR DESCRIPTION
## Changes proposed in this Pull Request
Plants that are about to be decommissioned in `planning_horizon` will be added as a new plant (retrofit) where the model chan choose to retrofit them instead of decommissioning them fully

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] OET SPDX license header added to all touched files.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
