### PR TITLE
refac: use latest `pypsa-eur` convention for Walloon data; change `build_powerplants` and `build_powerplants_BE`

### DIFF
--- a/config/config.walloon.yaml
+++ b/config/config.walloon.yaml
@@ -34,6 +34,13 @@ countries:
 - DE
 - LU
 
+walloon:
+  be_regions_file: data/walloon/be.json
+  existing_capacities_file: data/walloon/wal_2021_existing_capacities_2.csv
+  ntc_file: data/walloon/ntc_2030.csv
+  custom_potentials_file: data/walloon/custom_potentials.csv
+  custom_costs_file: data/walloon/custom_costs_rc.csv
+
 electricity:
   custom_powerplants: true
   walloon_reassignment: true

--- a/config/config.walloon.yaml
+++ b/config/config.walloon.yaml
@@ -38,8 +38,6 @@ walloon:
   be_regions_file: data/walloon/be.json
   existing_capacities_file: data/walloon/wal_2021_existing_capacities_2.csv
   ntc_file: data/walloon/ntc_2030.csv
-  custom_potentials_file: data/walloon/custom_potentials.csv
-  custom_costs_file: data/walloon/custom_costs_rc.csv
 
 electricity:
   custom_powerplants: true

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -40,6 +40,9 @@ rule build_powerplants:
         walloon_reassignment=config_provider(
             "electricity", "walloon_reassignment", default=False
         ),
+        walloon_regions_file=config_provider(
+            "walloon", "be_regions_file", default="data/walloon/be.json"
+        ),
         custom_powerplants=config_provider("electricity", "custom_powerplants"),
         everywhere_powerplants=config_provider("electricity", "everywhere_powerplants"),
         countries=config_provider("countries"),
@@ -48,7 +51,7 @@ rule build_powerplants:
         regions_onshore=resources("regions_onshore_base_s_{clusters}.geojson"),
         regions_offshore=resources("regions_offshore_base_s_{clusters}.geojson"),
         powerplants=rules.retrieve_powerplants.output["powerplants"],
-        custom_powerplants="data/custom_powerplants.csv",
+        custom_powerplants=resources("custom_powerplants.csv"),
     output:
         resources("powerplants_s_{clusters}.csv"),
     log:
@@ -64,7 +67,11 @@ rule build_powerplants:
 
 rule build_BE_powerplants:
     input:
-        wal_capacities="data/walloon/wal_2021_existing_capacities_2.csv",
+        wal_capacities=config_provider(
+            "walloon",
+            "existing_capacities_file",
+            default="data/walloon/wal_2021_existing_capacities_2.csv",
+        ),
         custom_powerplants="data/custom_powerplants.csv",
     output:
         custom_powerplants=resources("custom_powerplants.csv"),
@@ -656,7 +663,10 @@ rule process_cost_data:
     input:
         network=resources("networks/base_s.nc"),
         costs=rules.retrieve_cost_data.output["costs"],
-        custom_costs=config_provider("costs", "custom_cost_fn"),
+        custom_costs=lambda w: config_provider(
+            "walloon", "custom_costs_file", default=None
+        )(w)
+        or config_provider("costs", "custom_cost_fn")(w),
     output:
         resources("costs_{planning_horizons}_processed.csv"),
     log:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -663,10 +663,7 @@ rule process_cost_data:
     input:
         network=resources("networks/base_s.nc"),
         costs=rules.retrieve_cost_data.output["costs"],
-        custom_costs=lambda w: config_provider(
-            "walloon", "custom_costs_file", default=None
-        )(w)
-        or config_provider("costs", "custom_cost_fn")(w),
+        custom_costs=config_provider("costs", "custom_cost_fn"),
     output:
         resources("costs_{planning_horizons}_processed.csv"),
     log:

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1725,7 +1725,9 @@ rule prepare_sector_network:
             if config_provider("sector", "district_heating", "ates", "enable")(w)
             else []
         ),
-        ntc_csv="data/walloon/ntc_2030.csv",
+        ntc_csv=config_provider(
+            "walloon", "ntc_file", default="data/walloon/ntc_2030.csv"
+        ),
     output:
         resources(
             "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}.nc"

--- a/rules/walloon.smk
+++ b/rules/walloon.smk
@@ -6,7 +6,9 @@
 rule build_custom_BE_busmap:
     input:
         network=resources("networks/base_s.nc"),
-        be_shapefile="data/walloon/be.json",
+        be_shapefile=config_provider(
+            "walloon", "be_regions_file", default="data/walloon/be.json"
+        ),
     output:
         resources("resources/base_s_adm.csv"),
     log:

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -268,7 +268,9 @@ if __name__ == "__main__":
     ppl = gpd.GeoDataFrame(ppl, geometry=gpd.points_from_xy(ppl.lon, ppl.lat), crs=4326)
 
     if snakemake.params.walloon_reassignment:
-        n, ppl = ppl_by_subregion(n, ppl)
+        n, ppl = ppl_by_subregion(
+            n, ppl, gdf_path=snakemake.params.walloon_regions_file
+        )
 
     ppl = map_to_country_bus(ppl, regions)
 

--- a/scripts/lib/validation/config/_schema.py
+++ b/scripts/lib/validation/config/_schema.py
@@ -39,6 +39,7 @@ from scripts.lib.validation.config.transformers import TransformersConfig
 from scripts.lib.validation.config.transmission_projects import (
     TransmissionProjectsConfig,
 )
+from scripts.lib.validation.config.walloon import WalloonConfig
 
 
 class LoggingConfig(ConfigModel):
@@ -195,6 +196,10 @@ class ConfigSchema(BaseModel):
     costs: CostsConfig = Field(
         default_factory=CostsConfig,
         description="Cost assumptions configuration.",
+    )
+    walloon: WalloonConfig = Field(
+        default_factory=WalloonConfig,
+        description="Walloon-specific data configuration.",
     )
     clustering: ClusteringConfig = Field(
         default_factory=ClusteringConfig,

--- a/scripts/lib/validation/config/walloon.py
+++ b/scripts/lib/validation/config/walloon.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+
+"""Walloon-specific local input configuration."""
+
+from pydantic import Field
+
+from scripts.lib.validation.config._base import ConfigModel
+
+
+class WalloonConfig(ConfigModel):
+    """Configuration for local curated inputs used by the Walloon workflow."""
+
+    be_regions_file: str = Field(
+        "data/walloon/be.json",
+        description="GeoJSON/JSON file defining the Belgium 3-region split used for Walloon clustering and plant reassignment.",
+    )
+    existing_capacities_file: str = Field(
+        "data/walloon/wal_2021_existing_capacities_2.csv",
+        description="Custom Belgium/Walloon existing generator list used to build the custom powerplant table.",
+    )
+    ntc_file: str = Field(
+        "data/walloon/ntc_2030.csv",
+        description="NTC input data used when `electricity.apply_ntc_constraints` is enabled.",
+    )


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

- fixes some slight mistakes when merging master between `build_powerplants` and `build_powerplants_BE`
- refactor data inputs to be up-to-date with latest `pypsa-eur` convention

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
